### PR TITLE
Remove unnecessary expressions in format string

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -142,7 +142,7 @@ class PCParadiseBot(commands.Bot):
         print(" - ")
         print("Client is ready")
         print(
-            f"Logged in as {self.user.name}#{self.user.discriminator} (ID: {self.user.id})"
+            f"Logged in as {self.user} (ID: {self.user.id})"
         )
         print(f"Discord.py Version - {discord.__version__}")
         print(f"Prefix - {self.config.get('prefix')}")


### PR DESCRIPTION
A discord.py User instance converts to a user's name and discriminator when converted into a string. 