### PR TITLE
fix(cogs/config.py): add guild check to welcome channel config

### DIFF
--- a/src/cogs/config.py
+++ b/src/cogs/config.py
@@ -36,8 +36,10 @@ class Config(commands.Cog):
 
     @commands.command(name="disable_welcome_channel")
     @commands.has_permissions(administrator=True)
+    @commands.guild_only()
     async def disable_welcome_channel(self, msg: Message):
         """Command that allows an admin to disable the welcome channel for a server."""
+        assert msg.guild
         server_id = msg.guild.id
 
         # deletes existing welcome settings
@@ -74,11 +76,13 @@ class Config(commands.Cog):
             )
 
     @commands.command(name="enable_welcome_channel")
+    @commands.guild_only()
     @commands.has_permissions(administrator=True)
     async def enable_welcome_channel(self, msg: Message):
         """Enables a welcome channel where new users can verify \
         themselves by typing a certain word, and assigns \
         them a role based on their input."""
+        assert msg.guild
 
         server_id = msg.guild.id
 


### PR DESCRIPTION
We should only allow configuring these when the user is actually running the command in a guild. Administrator check indirectly already does this, but this adds an explicit check + asserts it to the type-system.